### PR TITLE
Use Python Alpine image for docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,10 @@
-FROM ubuntu:16.04
+FROM python:3.7-alpine
 
 LABEL maintainer="Thales César Giriboni <thalesgiriboni@gmail.com>"
 
-RUN apt-get update -y && \
-    apt-get install -y python3 python3-pip python3-dev
+RUN apk add tzdata
+
+RUN cp /usr/share/zoneinfo/America/Sao_Paulo /etc/localtime
 
 # We copy just the requirements.txt first to leverage Docker cache
 COPY ./requirements.txt /app/requirements.txt

--- a/app.json
+++ b/app.json
@@ -9,6 +9,9 @@
       "DEBUG": {
         "required": true
       },
+      "EMAIL_ENDPOINT": {
+        "required": true
+      },
       "EMAIL_PORT": {
         "required": true
       },
@@ -25,12 +28,6 @@
         "required": true
       },
       "MONGODB_URI": {
-        "required": true
-      },
-      "SENDGRID_PASSWORD": {
-        "required": true
-      },
-      "SENDGRID_USERNAME": {
         "required": true
       }
     },


### PR DESCRIPTION
Correção:

* Uso de imagem Alpine para Python no lugar do Ubuntu para diminuir o tamanho da imagem Docker da aplicação (resolve #29).