### PR TITLE
Habilitar outros intervalos para envio de relatórios

### DIFF
--- a/legislei/cron.py
+++ b/legislei/cron.py
@@ -15,11 +15,13 @@ def check_and_send_reports():
     return send_reports(check_reports_to_send())
 
 
-def send_reports(data):
+def send_reports(data, data_final = datetime.now()):
+    numero_semana = int(data_final.strftime("%V"))
     for user in data:
         reports = []
         inscricao = user.inscricoes
-        data_final = datetime.now()
+        if (numero_semana % (inscricao["intervalo"]/7) != 0):
+            continue
         data_inicial = (data_final - timedelta(days=int(inscricao["intervalo"])))
         for par in inscricao["parlamentares"]:
             try:

--- a/legislei/inscricoes.py
+++ b/legislei/inscricoes.py
@@ -42,5 +42,5 @@ class Inscricao():
             pull__inscricoes__parlamentares={'cargo': cargo, 'id': parlamentar_id})
 
     def alterar_configs(self, periodo, email):
-        if periodo >= 7 and periodo <= 28:
+        if periodo in [7, 14, 21, 28]:
             User.objects(email=email).update_one(set__inscricoes__intervalo=periodo)

--- a/legislei/models/inscricoes.py
+++ b/legislei/models/inscricoes.py
@@ -4,5 +4,5 @@ from legislei.models.relatorio import Parlamentar
 
 class Inscricoes(EmbeddedDocument):
 
-    intervalo = IntField()
+    intervalo = IntField(choices=[7, 14, 21, 28])
     parlamentares = EmbeddedDocumentListField(Parlamentar)

--- a/legislei/relatorios.py
+++ b/legislei/relatorios.py
@@ -1,5 +1,5 @@
 import json
-from datetime import datetime
+from datetime import datetime, timedelta
 
 import pytz
 
@@ -20,10 +20,12 @@ class Relatorios():
 
     def obter_relatorio(self, parlamentar, data_final, cargo, periodo):
         brasilia_tz = pytz.timezone('America/Sao_Paulo')
+        data_inicial = datetime.strptime(data_final, '%Y-%m-%d') - timedelta(days=int(periodo))
         relatorio = Relatorio.objects(
             parlamentar__id__=parlamentar,
             parlamentar__cargo=cargo,
-            data_final=brasilia_tz.localize(datetime.strptime(data_final, '%Y-%m-%d'))
+            data_final=brasilia_tz.localize(datetime.strptime(data_final, '%Y-%m-%d')),
+            data_inicial=brasilia_tz.localize(data_inicial)
         )
         if relatorio:
             return relatorio.first().to_dict()

--- a/legislei/templates/avaliacoes_home.html
+++ b/legislei/templates/avaliacoes_home.html
@@ -87,15 +87,15 @@
                 </div>
                 <div class="modal-body">
                     <label>
-                        Período de relatórios (em dias)
-                        <input
-                            type="number"
-                            min="7"
-                            max="28"
+                        Período de relatórios
+                        <select
                             name="periodo"
-                            value="{{ periodo }}"
                             id="configPeriodo"
-                            class="form-control" />
+                            class="form-control">
+                                <option value="7" {{ "selected" if periodo == 7 }}>Semanalmente</option>
+                                <option value="14" {{ "selected" if periodo == 14 }}>A cada duas semanas</option>
+                                <option value="28" {{ "selected" if periodo == 28 }}>Mensalmente</option>
+                        </select>
                     </label>
                 </div>
                 <div class="modal-footer">
@@ -170,7 +170,7 @@
                 alert('Houve o seguinte erro ao salvar: '+txtStatus);
             },
             success: () => {
-                alert('Opção em desenvolvimento.');
+                alert('Configurações alteradas.');
             }
         });
     }

--- a/tests/integration/test_app.py
+++ b/tests/integration/test_app.py
@@ -531,7 +531,7 @@ def set_up_db(db):
         pk=ObjectId("5c264b5e3a5efd576ecaf48e"),
         parlamentar=parlamentar_test,
         proposicoes=[],
-        data_inicial=TestApp.brasilia_tz.localize(datetime(2019, 1, 1)),
+        data_inicial=TestApp.brasilia_tz.localize(datetime(2018, 12, 31)),
         data_final=TestApp.brasilia_tz.localize(datetime(2019, 1, 7)),
         orgaos=[],
         eventos_presentes=eventos_presentes,

--- a/tests/unit/test_camara_deputados.py
+++ b/tests/unit/test_camara_deputados.py
@@ -290,7 +290,8 @@ class TestCamaraDeputadosHandler(unittest.TestCase):
         self.assertEqual(('Sim', 'Votação 1'), actual_response)
         mock.assert_no_pending_responses()
 
-    def test_obterVotoDeputado_fail_case(self):
+    @patch("builtins.print")
+    def test_obterVotoDeputado_fail_case(self, mock_print):
         mock = Mocker(self.dep.prop)
         mock.add_exception("obterVotacoesProposicao", CamaraDeputadosError)
 

--- a/tests/unit/test_cron.py
+++ b/tests/unit/test_cron.py
@@ -28,7 +28,7 @@ class TestCron(unittest.TestCase):
     
     @patch("legislei.cron.send_email")
     @patch("legislei.cron.render_template")
-    def test_send_reports(
+    def test_send_reports_multiplos_parlamentares(
             self,
             mock_render_template,
             mock_send_email
@@ -61,6 +61,117 @@ class TestCron(unittest.TestCase):
         mock_send_email.assert_called_once_with(
             "test@test.com", "<html>Nice</html>")
 
+    def _test_send_reports_multiplos_intervalos(
+        self,
+        agora,
+        mock_render_template,
+        mock_send_email
+    ):
+        brasilia_tz = pytz.timezone('America/Sao_Paulo')
+        data_final = datetime(agora.year, agora.month, agora.day)
+        data_final = brasilia_tz.localize(data_final)
+        parlamentar1 = Parlamentar(id='1', cargo='BR1')
+        Relatorio(parlamentar=parlamentar1, data_final=data_final).save()
+        mock_render_template.return_value = "<html>Nice</html>"
+        mock_send_email.return_value = True
+        users = [
+            User(
+                username='user1',
+                password='pwd',
+                email='test1@test.com',
+                inscricoes=Inscricoes(
+                    parlamentares=[parlamentar1],
+                    intervalo=7
+                )
+            ),
+            User(
+                username='user2',
+                password='pwd',
+                email='test2@test.com',
+                inscricoes=Inscricoes(
+                    parlamentares=[parlamentar1],
+                    intervalo=14
+                )
+            ),
+            User(
+                username='user4',
+                password='pwd',
+                email='test4@test.com',
+                inscricoes=Inscricoes(
+                    parlamentares=[parlamentar1],
+                    intervalo=28
+                )
+            )
+        ]
+
+        send_reports(users, data_final=agora)
+    
+    @patch("legislei.cron.send_email")
+    @patch("legislei.cron.render_template")
+    def test_send_reports_multiplos_intervalos_sem_4_semanas(
+            self,
+            mock_render_template,
+            mock_send_email
+    ):
+        self._test_send_reports_multiplos_intervalos(
+            agora=datetime(2019, 6, 29),
+            mock_render_template=mock_render_template,
+            mock_send_email=mock_send_email
+        )
+
+        self.assertEqual(mock_render_template.call_count, 2)
+        self.assertEqual(mock_send_email.call_count, 2)
+        mock_send_email.assert_has_calls(
+            [
+                call("test1@test.com", "<html>Nice</html>"),
+                call("test2@test.com", "<html>Nice</html>")
+            ]
+        )
+
+    @patch("legislei.cron.send_email")
+    @patch("legislei.cron.render_template")
+    def test_send_reports_multiplos_intervalos_com_4_semanas(
+            self,
+            mock_render_template,
+            mock_send_email
+    ):
+        self._test_send_reports_multiplos_intervalos(
+            agora=datetime(2019, 6, 15),
+            mock_render_template=mock_render_template,
+            mock_send_email=mock_send_email
+        )
+
+        self.assertEqual(mock_render_template.call_count, 3)
+        self.assertEqual(mock_send_email.call_count, 3)
+        mock_send_email.assert_has_calls(
+            [
+                call("test1@test.com", "<html>Nice</html>"),
+                call("test2@test.com", "<html>Nice</html>"),
+                call("test4@test.com", "<html>Nice</html>")
+            ]
+        )
+
+    @patch("legislei.cron.send_email")
+    @patch("legislei.cron.render_template")
+    def test_send_reports_multiplos_intervalos_semana_impar(
+            self,
+            mock_render_template,
+            mock_send_email
+    ):
+        self._test_send_reports_multiplos_intervalos(
+            agora=datetime(2019, 6, 8),
+            mock_render_template=mock_render_template,
+            mock_send_email=mock_send_email
+        )
+
+        self.assertEqual(mock_render_template.call_count, 1)
+        self.assertEqual(mock_send_email.call_count, 1)
+        mock_send_email.assert_has_calls(
+            [
+                call("test1@test.com", "<html>Nice</html>")
+            ]
+        )
+    
     @patch("legislei.cron.send_email")
     @patch("legislei.cron.render_template")
     @patch("legislei.cron.Relatorios")

--- a/tests/unit/test_cron.py
+++ b/tests/unit/test_cron.py
@@ -1,6 +1,6 @@
 import json
 import unittest
-from datetime import datetime
+from datetime import datetime, timedelta
 from unittest.mock import ANY, call, patch
 
 import pytz
@@ -37,12 +37,25 @@ class TestCron(unittest.TestCase):
         agora = datetime.now()
         data_final = datetime(agora.year, agora.month, agora.day)
         data_final = brasilia_tz.localize(data_final)
+        data_inicial = data_final - timedelta(days=7)
         parlamentar1 = Parlamentar(id='1', cargo='BR1')
         parlamentar2 = Parlamentar(id='2', cargo='BR2')
         parlamentar3 = Parlamentar(id='3', cargo='BR1')
-        Relatorio(parlamentar=parlamentar1, data_final=data_final).save()
-        Relatorio(parlamentar=parlamentar2, data_final=data_final).save()
-        Relatorio(parlamentar=parlamentar3, data_final=data_final).save()
+        Relatorio(
+            parlamentar=parlamentar1,
+            data_final=data_final,
+            data_inicial=data_inicial
+        ).save()
+        Relatorio(
+            parlamentar=parlamentar2,
+            data_final=data_final,
+            data_inicial=data_inicial
+        ).save()
+        Relatorio(
+            parlamentar=parlamentar3,
+            data_final=data_final,
+            data_inicial=data_inicial
+        ).save()
         mock_render_template.return_value = "<html>Nice</html>"
         mock_send_email.return_value = True
         user = [User(
@@ -55,7 +68,7 @@ class TestCron(unittest.TestCase):
             )
         )]
 
-        send_reports(user)
+        send_reports(user, data_final=agora)
 
         self.assertEqual(mock_render_template.call_count, 1)
         mock_send_email.assert_called_once_with(
@@ -71,7 +84,21 @@ class TestCron(unittest.TestCase):
         data_final = datetime(agora.year, agora.month, agora.day)
         data_final = brasilia_tz.localize(data_final)
         parlamentar1 = Parlamentar(id='1', cargo='BR1')
-        Relatorio(parlamentar=parlamentar1, data_final=data_final).save()
+        Relatorio(
+            parlamentar=parlamentar1,
+            data_final=data_final,
+            data_inicial=data_final - timedelta(days=7)
+        ).save()
+        Relatorio(
+            parlamentar=parlamentar1,
+            data_final=data_final,
+            data_inicial=data_final - timedelta(days=14)
+        ).save()
+        Relatorio(
+            parlamentar=parlamentar1,
+            data_final=data_final,
+            data_inicial=data_final - timedelta(days=28)
+        ).save()
         mock_render_template.return_value = "<html>Nice</html>"
         mock_send_email.return_value = True
         users = [


### PR DESCRIPTION
Nova funcionalidade:

* Possibilidade de configuração de período de envio de relatórios: semanalmente, a cada duas semanas e mensalmente (resolve #43).