### PR TITLE
Fix wrong date for report generation

### DIFF
--- a/legislei/cron.py
+++ b/legislei/cron.py
@@ -16,7 +16,9 @@ def check_and_send_reports():
     return send_reports(check_reports_to_send())
 
 
-def send_reports(data, data_final = datetime.now()):
+def send_reports(data, data_final = None):
+    if data_final == None:
+        data_final = datetime.now()
     numero_semana = int(data_final.strftime("%V"))
     for user in data:
         reports = []


### PR DESCRIPTION
Correção:

* Relatórios gerados pelo sistema estavam vindo com data do dia anterior (sexta-feira ao invés de sábado).