### PR TITLE
Add possibility of microseconds in MongoDateTime

### DIFF
--- a/legislei/controllers/dto.py
+++ b/legislei/controllers/dto.py
@@ -9,7 +9,10 @@ from legislei.app import rest_api_v1
 class MongoDateTime(fields.DateTime):
     def format(self, value):
         if isinstance(value, str):
-            date = datetime.strptime(value, "%Y-%m-%d %H:%M:%S")
+            try:
+                date = datetime.strptime(value, "%Y-%m-%d %H:%M:%S")
+            except ValueError:
+                date = datetime.strptime(value, "%Y-%m-%d %H:%M:%S.%f")
         else:
             date = datetime.fromtimestamp(value['$date']/1000, pytz.UTC)
         brasilia_tz = pytz.timezone('America/Sao_Paulo')


### PR DESCRIPTION
Correção:

* Validação de DTO de proposição aceita microsegundos (resolve #62).